### PR TITLE
[doc] Fix toctree of documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,9 +29,13 @@
 import os
 import sys
 
+sys.path.insert(0, os.path.abspath(os.path.curdir))
 sys.path.insert(0, os.path.abspath('../'))
 
 import braintaichi
+import auto_generater
+
+os.makedirs('api', exist_ok=True)
 
 
 # -- Project information -----------------------------------------------------
@@ -57,6 +61,7 @@ extensions = [
   'sphinx.ext.viewcode',
   'sphinx_autodoc_typehints',
   'myst_nb',
+  'matplotlib.sphinxext.plot_directive',
   'sphinx_thebe',
   'sphinx_design'
 ]
@@ -118,7 +123,7 @@ thebe_config = {
 
 
 html_theme_options = {
-    'show_toc_level': 2,
+    'show_toc_level': 1,
 }
 
 # -- Options for myst ----------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,13 +23,22 @@ See also the BDP ecosystem
 
 We are building the `brain dynamics programming ecosystem <https://ecosystem-for-brain-dynamics.readthedocs.io/>`_.
 
-
 ----
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Tutorial
+
+   tutorial/braintaichi_intro.ipynb
+   tutorial/complete_example.ipynb
 
 
 .. toctree::
-   :hidden:
-   :maxdepth: 2
-   tutorial/braintaichi_intro.ipynb
-   api.rst
+   :maxdepth: 1
+   :caption: API Documentation
 
+   apis/changelog.md
+   apis/operator-registration.rst
+   apis/sparse-operators.rst
+   apis/event-operators.rst
+   apis/jitconn-operators.rst


### PR DESCRIPTION
This pull request includes several changes to the documentation configuration and structure. The most important changes are the addition of new modules and adjustments to the table of contents.

### Documentation Configuration Updates:

* [`docs/conf.py`](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3R32-R38): Added the current directory to the system path and imported the `auto_generater` module.
* [`docs/conf.py`](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3R64): Included the `matplotlib.sphinxext.plot_directive` extension to the list of Sphinx extensions.
* [`docs/conf.py`](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3L121-R126): Changed the `show_toc_level` option in `html_theme_options` from 2 to 1.

### Documentation Structure Adjustments:

* [`docs/index.rst`](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534L26-R44): Modified the table of contents to separate the tutorial and API documentation sections, and updated the included files.