### PR TITLE
[doc] Fix bug

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,6 @@ extensions = [
   'sphinx.ext.viewcode',
   'sphinx_autodoc_typehints',
   'myst_nb',
-  'matplotlib.sphinxext.plot_directive',
   'sphinx_thebe',
   'sphinx_design'
 ]


### PR DESCRIPTION
This pull request includes a small change to the `docs/conf.py` file. The change removes the `matplotlib.sphinxext.plot_directive` extension from the list of Sphinx extensions.

* [`docs/conf.py`](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3L64): Removed the `matplotlib.sphinxext.plot_directive` extension from the Sphinx extensions list.