### PR TITLE
[release] v0.0.5

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.13", "3.10", "3.11", "3.12"]
+        python-version: [ "3.10", "3.11", "3.12"]
 
     steps:
       - name: Cancel Previous Runs
@@ -59,7 +59,7 @@ jobs:
 #    strategy:
 #      fail-fast: false
 #      matrix:
-#        python-version: [ "3.13", "3.10", "3.11", "3.12"]
+#        python-version: [ "3.10", "3.11", "3.12"]
 #
 #    steps:
 #      - name: Cancel Previous Runs
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.13", "3.10", "3.11", "3.12"]
+        python-version: [ "3.10", "3.11", "3.12"]
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12"]
+        python-version: [ "3.13", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Cancel Previous Runs
@@ -59,7 +59,7 @@ jobs:
 #    strategy:
 #      fail-fast: false
 #      matrix:
-#        python-version: [ "3.9", "3.10", "3.11", "3.12"]
+#        python-version: [ "3.13", "3.10", "3.11", "3.12"]
 #
 #    steps:
 #      - name: Cancel Previous Runs
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12"]
+        python-version: [ "3.13", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Cancel Previous Runs

--- a/braintaichi/__init__.py
+++ b/braintaichi/__init__.py
@@ -18,11 +18,11 @@
 
 __all__ = [
     '__version__',
-    '__minimal_taichi_version__',
+    '__selected_taichi_version__',
 ]
 
 __version__ = "0.0.4"
-__minimal_taichi_version__ = (1, 7, 2)
+__selected_taichi_version__ = (1, 7, 3)
 
 import ctypes
 import os
@@ -37,9 +37,9 @@ with open(os.devnull, 'w') as devnull:
         import taichi as ti  # noqa
     except ModuleNotFoundError:
         raise ModuleNotFoundError(
-            f'We need taichi>={__minimal_taichi_version__}. '
-            f'Currently you can install taichi>={__minimal_taichi_version__} through:\n\n'
-            f'> pip install taichi -U'
+            f'We need taichi =={__selected_taichi_version__}. '
+            f'Currently you can install taichi=={__selected_taichi_version__} through:\n\n'
+            f'> pip install taichi=={__selected_taichi_version__}\n'
             # '> pip install -i https://pypi.taichi.graphics/simple/ taichi-nightly'
         )
     finally:
@@ -47,11 +47,11 @@ with open(os.devnull, 'w') as devnull:
 del old_stdout, devnull
 
 # check Taichi version
-if ti.__version__ < __minimal_taichi_version__:
+if ti.__version__ != __selected_taichi_version__:
     raise RuntimeError(
-        f'We need taichi>={__minimal_taichi_version__}. '
-        f'Currently you can install taichi>={__minimal_taichi_version__} through:\n\n'
-        f'> pip install taichi -U'
+        f'We need taichi=={__selected_taichi_version__}. '
+        f'Currently you can install taichi>={__selected_taichi_version__} through:\n\n'
+        f'> pip install taichi=={__selected_taichi_version__}\n'
         # '> pip install -i https://pypi.taichi.graphics/simple/ taichi-nightly'
     )
 

--- a/braintaichi/__init__.py
+++ b/braintaichi/__init__.py
@@ -21,7 +21,7 @@ __all__ = [
     '__selected_taichi_version__',
 ]
 
-__version__ = "0.0.4"
+__version__ = "0.0.5"
 __selected_taichi_version__ = (1, 7, 3)
 
 import ctypes

--- a/braintaichi/_primitive/_ad_support.py
+++ b/braintaichi/_primitive/_ad_support.py
@@ -20,7 +20,7 @@ from functools import partial
 
 import jax
 from jax import tree_util
-from jax.core import Primitive
+from jax.extend.core import Primitive
 from jax.interpreters import ad
 
 __all__ = [

--- a/braintaichi/_primitive/_mlir_translation_rule.py
+++ b/braintaichi/_primitive/_mlir_translation_rule.py
@@ -393,9 +393,9 @@ def _preprocess_kernel_call_gpu(
 
 
 def _kernel_to_code(kernel, abs_ins, abs_outs, platform):
-    codes = f'[taichi {ti.__version__} {platform} kernel]\n' + get_source_with_dependencies(kernel)
-    codes += '\n[ins]: {}'.format("-".join([f'{v.dtype}[{v.shape}]' for v in abs_ins]))
-    codes += '\n[outs]: {}'.format("-".join([f'{v.dtype}[{v.shape}]' for v in abs_outs]))
+    codes = f'[taichi {ti.__version__} {platform} kernel]\n{get_source_with_dependencies(kernel)}'
+    codes += f"""\n[ins]: {"-".join([f'{v.dtype}[{v.shape}]' for v in abs_ins])}"""
+    codes += f"""\n[outs]: {"-".join([f'{v.dtype}[{v.shape}]' for v in abs_outs])}"""
     return codes
 
 

--- a/braintaichi/_primitive/_mlir_translation_rule.py
+++ b/braintaichi/_primitive/_mlir_translation_rule.py
@@ -393,7 +393,7 @@ def _preprocess_kernel_call_gpu(
 
 
 def _kernel_to_code(kernel, abs_ins, abs_outs, platform):
-    codes = f'[taichi {platform} kernel]\n' + get_source_with_dependencies(kernel)
+    codes = f'[taichi {ti.__version__} {platform} kernel]\n' + get_source_with_dependencies(kernel)
     codes += '\n[ins]: {}'.format("-".join([f'{v.dtype}[{v.shape}]' for v in abs_ins]))
     codes += '\n[outs]: {}'.format("-".join([f'{v.dtype}[{v.shape}]' for v in abs_outs]))
     return codes

--- a/ci/linux/gpu/pyproject.toml
+++ b/ci/linux/gpu/pyproject.toml
@@ -39,7 +39,7 @@ build-backend = "setuptools.build_meta"
 [project]
 requires-python = ">=3.9, <3.13"
 name = "braintaichi"
-version = "0.0.4"
+version = "0.0.5"
 
 [tool.cibuildwheel.linux]
 before-all = "sh prepare_build_wheel_on_cuda.sh"

--- a/ci/linux/gpu/pyproject.toml
+++ b/ci/linux/gpu/pyproject.toml
@@ -31,7 +31,7 @@ requires = [
     "pybind11",
     "setuptools_scm[toml]>=3.4",
     "cmake",
-    "taichi==1.7.2",
+    "taichi==1.7.3",
 ]
 
 build-backend = "setuptools.build_meta"

--- a/ci/mac/arm64/pyproject3.10.toml
+++ b/ci/mac/arm64/pyproject3.10.toml
@@ -39,7 +39,7 @@ build-backend = "setuptools.build_meta"
 [project]
 requires-python = ">=3.10, <3.11"
 name = "braintaichi"
-version = "0.0.4"
+version = "0.0.5"
 
 [tool.cibuildwheel.linux]
 before-all = "sh prepare_build_wheel_on_cuda.sh"

--- a/ci/mac/arm64/pyproject3.11.toml
+++ b/ci/mac/arm64/pyproject3.11.toml
@@ -39,7 +39,7 @@ build-backend = "setuptools.build_meta"
 [project]
 requires-python = ">=3.11, <3.12"
 name = "braintaichi"
-version = "0.0.4"
+version = "0.0.5"
 
 [tool.cibuildwheel.linux]
 before-all = "sh prepare_build_wheel_on_cuda.sh"

--- a/ci/mac/arm64/pyproject3.12.toml
+++ b/ci/mac/arm64/pyproject3.12.toml
@@ -39,7 +39,7 @@ build-backend = "setuptools.build_meta"
 [project]
 requires-python = ">=3.12, <3.13"
 name = "braintaichi"
-version = "0.0.4"
+version = "0.0.5"
 
 [tool.cibuildwheel.linux]
 before-all = "sh prepare_build_wheel_on_cuda.sh"

--- a/ci/mac/arm64/pyproject3.9.toml
+++ b/ci/mac/arm64/pyproject3.9.toml
@@ -39,7 +39,7 @@ build-backend = "setuptools.build_meta"
 [project]
 requires-python = ">=3.9, <3.10"
 name = "braintaichi"
-version = "0.0.4"
+version = "0.0.5"
 
 [tool.cibuildwheel.linux]
 before-all = "sh prepare_build_wheel_on_cuda.sh"

--- a/ci/mac/x86_64/pyproject3.10.toml
+++ b/ci/mac/x86_64/pyproject3.10.toml
@@ -39,7 +39,7 @@ build-backend = "setuptools.build_meta"
 [project]
 requires-python = ">=3.10, <3.11"
 name = "braintaichi"
-version = "0.0.4"
+version = "0.0.5"
 
 [tool.cibuildwheel.linux]
 before-all = "sh prepare_build_wheel_on_cuda.sh"

--- a/ci/mac/x86_64/pyproject3.11.toml
+++ b/ci/mac/x86_64/pyproject3.11.toml
@@ -39,7 +39,7 @@ build-backend = "setuptools.build_meta"
 [project]
 requires-python = ">=3.11, <3.12"
 name = "braintaichi"
-version = "0.0.4"
+version = "0.0.5"
 
 [tool.cibuildwheel.linux]
 before-all = "sh prepare_build_wheel_on_cuda.sh"

--- a/ci/mac/x86_64/pyproject3.12.toml
+++ b/ci/mac/x86_64/pyproject3.12.toml
@@ -39,7 +39,7 @@ build-backend = "setuptools.build_meta"
 [project]
 requires-python = ">=3.12, <3.13"
 name = "braintaichi"
-version = "0.0.4"
+version = "0.0.5"
 
 [tool.cibuildwheel.linux]
 before-all = "sh prepare_build_wheel_on_cuda.sh"

--- a/ci/mac/x86_64/pyproject3.9.toml
+++ b/ci/mac/x86_64/pyproject3.9.toml
@@ -39,7 +39,7 @@ build-backend = "setuptools.build_meta"
 [project]
 requires-python = ">=3.9, <3.10"
 name = "braintaichi"
-version = "0.0.4"
+version = "0.0.5"
 
 [tool.cibuildwheel.linux]
 before-all = "sh prepare_build_wheel_on_cuda.sh"

--- a/copy_so_linux.sh
+++ b/copy_so_linux.sh
@@ -4,7 +4,7 @@ yum install glibc-devel -y
 
 yum install --disableplugin=fastmirror -y python3-devel.x86_64
 
-pip install taichi==1.7.2
+pip install taichi==1.7.3
 chmod +x ./copy_so_linux.py
 python copy_so_linux.py
 

--- a/copy_so_macOS.sh
+++ b/copy_so_macOS.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-pip install taichi==1.7.2
+pip install taichi==1.7.3
 chmod +x ./copy_so_macOS.py
 python copy_so_macOS.py
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ requires = [
     "pybind11",
     "setuptools_scm[toml]>=3.4",
     "cmake",
-    "taichi==1.7.2",
+    "taichi==1.7.3",
 ]
 
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ build-backend = "setuptools.build_meta"
 [project]
 requires-python = ">=3.9, <3.13"
 name = "braintaichi"
-version = "0.0.4"
+version = "0.0.5"
 
 [tool.cibuildwheel.linux]
 before-all = "sh ci/linux/gpu/prepare_build_wheel_on_cuda.sh"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jax>=0.4.16
+jax>=0.4.16,<0.6.0
 jaxlib
 numpy
 brainstate


### PR DESCRIPTION
This pull request updates the Taichi dependency management in the `braintaichi` library to enforce a specific version requirement and improves version-related metadata in kernel code generation. The most important changes include replacing the minimal version check with an exact version requirement, updating related error messages, and embedding the Taichi version in kernel metadata.

### Updates to Taichi dependency management:

* [`braintaichi/__init__.py`](diffhunk://#diff-83b6a56514b4d2d68f1a9b2f099ad010463f0a434a5f61d9d83c337374bc58bdL21-R25): Replaced `__minimal_taichi_version__` with `__selected_taichi_version__` to enforce an exact version requirement (`1.7.3` instead of `>=1.7.2`). Updated error messages to reflect the new exact version requirement. [[1]](diffhunk://#diff-83b6a56514b4d2d68f1a9b2f099ad010463f0a434a5f61d9d83c337374bc58bdL21-R25) [[2]](diffhunk://#diff-83b6a56514b4d2d68f1a9b2f099ad010463f0a434a5f61d9d83c337374bc58bdL40-R54)

### Improvements to kernel code generation:

* [`braintaichi/_primitive/_mlir_translation_rule.py`](diffhunk://#diff-7315c983fbc89e069ad0478af665e6d21c14f1b4d8940c5fdaac61f2f15b266aL396-R396): Modified `_kernel_to_code` to include the exact Taichi version (`ti.__version__`) in the generated kernel metadata.

## Summary by Sourcery

Enforce exact Taichi version requirement and update version-related metadata in kernel code generation

Enhancements:
- Replace minimal Taichi version check with an exact version requirement
- Include exact Taichi version in kernel metadata generation

Chores:
- Bump library version from 0.0.4 to 0.0.5 across all configuration files